### PR TITLE
Enforce naming convention

### DIFF
--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -25,18 +25,27 @@
   "Subscribes an event handler for the given topic. The handler will be called
   whenever an event is emitted for the given topic, and any optional args from
   emit! will be passed as arguments to the handler-fn."
-  [topic handler-fn]
-  (let [c (chan)]
-    (sub publication topic c)
-    (go-loop []
-      (when-let [[topic & msg] (<! c)]
-        (apply handler-fn msg)
-        (recur)))))
+  ([topic docstring handler-fn]
+   (let [c (chan)]
+     (sub publication topic c)
+     (go-loop []
+       (when-let [[topic & msg] (<! c)]
+         (apply handler-fn msg)
+         (recur)))))
+  ([topic handler-fn]
+   (handle topic "I'm too lazy to describe my handlers." handler-fn)))
 
-;; Handle ::connection-open events by connecting.
-(handle ::connection-open
+;; +--------------------------------------------------------------------------+
+;; | Websockets                                                               |
+;; +--------------------------------------------------------------------------+
+
+(handle ::connect-bot
+  "Retrieves the websocket URL for a given bot token and emits this token in a
+  command called ::connect-websocket commanding that a connection be made to
+  the URL."
   (fn [token]
-    (emit! ::connection-bind
+    (emit! ::connect-websocket
+      token
       (-> (format "https://slack.com/api/rtm.start?token=%s" token)
         (http/get)
         (deref)
@@ -44,26 +53,39 @@
         (read-str :key-fn string->keyword)
         (:url)))))
 
-;; Handle ::connection-bind by actually binding the websocket.
-(handle ::connection-bind
-  (fn [url]
+(handle ::connect-websocket
+  "Connects to the websocket temporarily available at `url` and emits the
+  following two events:
+
+  [::websocket-connected url socket] for handlers interested in the socket.
+  [::bot-connected token] for handlers interested in the token."
+  (fn [token url]
     (let [socket (connect url
                    :on-receive
                    (fn [raw]
                      (emit! ::receive-message
                        (read-str raw :key-fn string->keyword))))]
       (reset! connection socket)
-      (emit! ::connection-bound socket))))
+      (emit! ::websocket-connected url socket)
+      (emit! ::bot-connected token))))
 
-;; Handle ::send-message events by sending them to the Slack server.
-(handle ::send-message
-  (fn [msg]
-    (send-msg @connection (string->slack-json msg))))
+;; +--------------------------------------------------------------------------+
+;; | Message handling                                                         |
+;; +--------------------------------------------------------------------------+
 
-;; Handle ::receive-message events by publishing them with :type as topic.
 (handle ::receive-message
+  "Handles the reception of a message by republishing it with a keywordized
+  topic matching those described in the Slack API. This makes it easy to only
+  subscribe to the kind of events you want, such as :message, :presence_change,
+  etc."
   (fn [msg]
     (let [topic (cond (:type msg)     (:type msg)
                       (:reply_to msg) "reply"
                       :else           "unknown")]
       (go (>! publisher [(string->keyword topic) msg])))))
+
+
+(handle ::send-message
+  "Sends a message to the currently open websocket."
+  (fn [msg]
+    (send-msg @connection (string->slack-json msg))))


### PR DESCRIPTION
After the deliberation in #3, a new naming convention has been affected. A possible docstring for handlers is introduced, but it isn't actually used, as it requires an IObj, and core.async channels just aren't IObjs.
