### PR TITLE
Add `local-install` task to ease dependency management

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -22,3 +22,13 @@
       (use 'client-test 'converters-test)
       (exp/run-all-tests)
       identity)))
+
+(deftask local-install
+  "Builds a jar of this project and place it in your local m2 repo."
+  []
+  (comp
+   (aot :namespace '#{slacker.client slacker.converters})
+   (pom :project 'slacker
+        :version "0.1.0")
+   (jar)
+   (install)))


### PR DESCRIPTION
This will allow bot authors to

``` bash
git clone https://github.com/emiln/slacker
cd slacker
boot build
```

and then simply include `[slacker "0.1.0"]` as a dependency for their bot project.
