### PR TITLE
#16 Rethink testing strategy

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,34 +1,22 @@
 (set-env!
   :source-paths #{"src"}
   :dependencies
-  '[[expectations "2.0.9"]
+  '[[adzerk/boot-test "1.0.4" :scope "test"]
     [http-kit "2.1.16"]
     [org.clojure/core.async "0.1.346.0-17112a-alpha"]
     [org.clojure/data.json "0.2.5"]
     [stylefruits/gniazdo "0.3.1"]])
 
-;; Poor solution. Expectations are loaded for absolutely everything, which
-;; isn't the intention.
-;; TODO: figure how to properly load expectations only in the test task.
-(require '[expectations :as exp])
-(exp/disable-run-on-shutdown)
+(task-options!
+  pom {:project 'emiln/slacker
+       :version "1.0.0"
+       :description "An enthusiastically asynchronous Slack bot library."
+       :url "https://github.com/emiln/slacker"
+       :scm {:url "https://github.com/emiln/slacker"}})
 
-;; Much like above. This isn't really a good approach to testing. Help wanted!
-(deftask test
+(deftask slacker-test
+  "Run the unit tests for Slacker in a pod."
   []
-  (fn middleware [next-handler]
-    (fn handler [fileset]
-      (set-env! :source-paths #(conj % "unit-tests"))
-      (use 'client-test 'converters-test)
-      (exp/run-all-tests)
-      identity)))
-
-(deftask local-install
-  "Builds a jar of this project and place it in your local m2 repo."
-  []
-  (comp
-   (aot :namespace '#{slacker.client slacker.converters})
-   (pom :project 'emiln/slacker
-        :version "1.0.0")
-   (jar)
-   (install)))
+  (merge-env! :source-paths #{"unit-tests"})
+  (require 'adzerk.boot-test)
+  ((resolve 'adzerk.boot-test/test)))

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
   environment:
     BOOT_CLOJURE_VERSION: 1.6.0
     BOOT_VERSION: 2.0.0-rc14
+    JAVA_OPTS: -XXMaxPermSize=512M
 
 ## Download and install Boot
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
   override:
     - boot checkout
   cache_directories:
-    - ".m2"
+    - "~/.m2"
 
 ## Run the Slacker tests
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 ## Download and install Boot
 dependencies:
   pre:
-    - wget -O ~/boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
+    - wget -O ~/boot/boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
     - chmod u+x "~/boot/boot"
   cache_directories:
     - "~/boot"

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,4 @@ dependencies:
 ## Run the Slacker tests
 test:
   override:
-    - ~/boot/boot slacker-test
+    - "BOOT_VERSION=${BOOT_VERSION} BOOT_CLOJURE_VERSION=${BOOT_CLOJURE_VERSION} ~/boot/boot slacker-test"

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   environment:
     BOOT_CLOJURE_VERSION: 1.6.0
     BOOT_VERSION: 2.0.0-rc14
-    JAVA_OPTS: -XXMaxPermSize=512M
+    JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxPermSize=512m"
 
 ## Download and install Boot
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -9,10 +9,9 @@ machine:
 ## Download and install Boot
 dependencies:
   pre:
-    - wget "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
-    - chmod u+x boot.sh
-    - mv boot.sh boot
-    - export PATH=$PATH:.
+    - wget -O boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
+    - chmod a+x boot
+    - mv boot /usr/bin/boot
 
 ## Run the Slacker tests
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
   pre:
     - wget "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
     - chmod u+x boot.sh
+    - export PATH=$PATH:.
 
 ## Run the Slacker tests
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,10 @@ machine:
 ## Download and install Boot
 dependencies:
   pre:
-    - wget -O ~/boot/boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
-    - chmod u+x "~/boot/boot"
-  cache_directories:
-    - "~/boot"
+    - wget "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
+    - chmod u+x boot.sh
 
 ## Run the Slacker tests
 test:
   override:
-    - "BOOT_VERSION=${BOOT_VERSION} BOOT_CLOJURE_VERSION=${BOOT_CLOJURE_VERSION} ~/boot/boot slacker-test"
+    - "boot.sh slacker-test"

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
   pre:
     - wget "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
     - chmod u+x boot.sh
+    - mv boot.sh boot
     - export PATH=$PATH:.
 
 ## Run the Slacker tests

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
   pre:
     - wget -O boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
     - chmod a+x boot
-    - mv boot /usr/bin/boot
+    - mv boot /home/ubuntu/bin
 
 ## Run the Slacker tests
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   environment:
     BOOT_CLOJURE_VERSION: 1.6.0
     BOOT_VERSION: 2.0.0-rc14
-    JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxPermSize=512m"
+    JAVA_OPTS: -XXMaxPermSize=256m
 
 ## Download and install Boot
 dependencies:
@@ -13,6 +13,10 @@ dependencies:
     - wget -O boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
     - chmod a+x boot
     - mv boot /home/ubuntu/bin
+  override:
+    - boot checkout
+  cache_directories:
+    - ".m2"
 
 ## Run the Slacker tests
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+## Customize the test machine
+machine:
+
+  # Pin the Boot and Clojure version
+  environment:
+    BOOT_CLOJURE_VERSION: 1.6.0
+    BOOT_VERSION: 2.0.0-rc14
+
+## Download and install Boot
+dependencies:
+  pre:
+    - wget -O ~/boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
+    - chmod u+x "~/boot/boot"
+  cache_directories:
+    - "~/boot"
+
+## Run the Slacker tests
+test:
+  override:
+    - ~/boot/boot slacker-test

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,4 @@ dependencies:
 ## Run the Slacker tests
 test:
   override:
-    - "boot.sh slacker-test"
+    - "boot slacker-test"

--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -4,7 +4,7 @@
   (:require
     [clojure.core.async :refer [<! >! chan go go-loop pub sub]]
     [clojure.data.json :refer [read-str]]
-    [clojure.string :refer [lower-case replace]]
+    [clojure.string :refer [lower-case]]
     [org.httpkit.client :as http]
     [gniazdo.core :refer [connect send-msg]]
     [slacker.converters :refer [string->keyword string->slack-json]]))

--- a/unit-tests/client_test.clj
+++ b/unit-tests/client_test.clj
@@ -1,36 +1,26 @@
 (ns client-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer [deftest is testing]]
             [slacker.client :refer [emit! handle]]))
 
-;;; Calling emit should trigger a handler for the given topic.
+(deftest about-emit!
+  (testing "Facts about emit!"
+    (testing "Calling emit! should trigger a handler for the topic"
+      (let [result (promise)
+            handler (handle :test #(deliver result true))]
+        (emit! :test)
+        (is @result)))
 
-;; Arrange.
-(let [result (promise)
-      handler (handle :test #(deliver result true))]
-  ;; Act.
-  (emit! :test)
-  ;; Assert.
-  (expect true @result))
+    (testing "Calling emit! should trigger multiple handlers for the topic"
+      (let [results (repeatedly 3 promise)]
+        (doseq [result results]
+          (handle :topic #(deliver result true)))
+        (emit! :topic)
+        (is (every? true? (map deref results)))))
 
-;;; Calling emit should trigger multiple handlers for the given topic.
-
-;; Arrange
-(let [results (repeatedly 3 promise)]
-  (doseq [result results]
-    (handle :topic #(deliver result true)))
-  ;; Act.
-  (emit! :topic)
-  ;; Assert.
-  (expect true (every? true? (map deref results))))
-
-;;; Calling emit should correctly pass additional arguments to the handler.
-
-;; Arrange.
-(let [result (promise)
-      object (Object.)]
-  (handle :with-arguments
-    (fn [a b c] (deliver result [a b c])))
-  ;; Act.
-  (emit! :with-arguments "string" 12345 object)
-  ;; Assert.
-  (expect ["string" 12345 object] @result))
+    (testing "Calling emit should pass additional arguments to the handler"
+      (let [result (promise)
+            object (Object.)]
+        (handle :with-arguments
+          (fn [a b c] (deliver result [a b c])))
+        (emit! :with-arguments "string" 12345 object)
+        (is (= ["string" 12345 object] @result))))))

--- a/unit-tests/converters_test.clj
+++ b/unit-tests/converters_test.clj
@@ -1,41 +1,32 @@
 (ns converters-test
   (:require
     [clojure.data.json :refer [read-str write-str]]
-    [expectations :refer [expect]]
+    [clojure.test :refer [deftest is testing]]
     [slacker.converters :refer [string->keyword string->slack-json]]))
 
-;; +--------------------------------------------------------------------------+
-;; | Facts about string->keyword:                                             |
-;; +--------------------------------------------------------------------------+
+(deftest about-string->keyword
+  (testing "Facts about string->keyword"
+    (testing "Converting underscores to dashes"
+      (is (= :an-underscored-json-key
+             (string->keyword "an_underscored_json_key"))))
+    (testing "Converting any casing to lower-case"
+      (is (= :uppercasestring
+             (string->keyword "UPPERCASESTRING")))
+      (is (= :mixedcasestring
+             (string->keyword "MiXedCAsEstRINg"))))
+    (testing "Not doing anything special about camelCase"
+      (is (= :camelcasestring
+             (string->keyword "CamelCaseString"))))))
 
-;; It should convert underscores to dashes.
-(expect :an-underscored-json-key
-  (string->keyword "an_underscored_json_key"))
-
-;; It should convert any casing to lower-case.
-(expect :uppercasestring
-  (string->keyword "UPPERCASESTRING"))
-(expect :mixedcasestring
-  (string->keyword "MiXedCAsEstRINg"))
-
-;; It is not supposed to do anything special about camel case.
-(expect :camelcasestring
-  (string->keyword "CamelCaseString"))
-
-;; +--------------------------------------------------------------------------+
-;; | Facts about string->slack-json:                                          |
-;; +--------------------------------------------------------------------------+
-
-;; It should use its default values for channel and type when they are
-;; not supplied as arguments. Note that "id" can't be expected to have a
-;; default value as its value varies.
-(expect {"channel" "C03RGK7FC",
-         "id" 1,
-         "text" "test",
-         "type" "message"}
-  (read-str (string->slack-json "C03RGK7FC" "test" :id 1)))
-
-;; It should assign unique ids for two consecutive messages.
-(let [id1 (-> (string->slack-json "C03RGK7FC" "test") (read-str) (get "id"))
-      id2 (-> (string->slack-json "C03RGK7FC" "test") (read-str) (get "id"))]
-  (expect (not= id1 id2)))
+(deftest about-string->slack-json
+  (testing "Facts about string->slack-json"
+    (testing "Using default values for type when it is not supplied"
+      (is (= {"channel" "C03RGK7FC",
+              "id" 1,
+              "text" "test",
+              "type" "message"}
+             (read-str (string->slack-json "C03RGK7FC" "test" :id 1)))))
+    (testing "Assigning unique ids for consecutive messages"
+      (let [id1 (-> (string->slack-json "chan" "text") (read-str) (get "id"))
+            id2 (-> (string->slack-json "chan" "text") (read-str) (get "id"))]
+        (is (not= id1 id2))))))


### PR DESCRIPTION
There is a new boot task called `slacker-test`, which uses the excellent
boot-test library, and which runs all `deftest` functions found. The switch
to regular clojure.test is made tolerable primarily because boot-test makes a
good effort to present human-readable diffs in expected and actual input -
not entirely unlike expectations before it.

This rewrites a lot of lines, but shouldn't touch on anything dangerous.

Accepting this closes #16.
