### PR TITLE
Issue #21: Logging

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,6 +6,7 @@
     [http-kit "2.1.16"]
     [org.clojure/core.async "0.1.346.0-17112a-alpha"]
     [org.clojure/data.json "0.2.5"]
+    [org.clojure/tools.logging "0.3.1"]
     [stylefruits/gniazdo "0.3.1"]])
 
 (require '[adzerk.bootlaces :refer :all])


### PR DESCRIPTION
Introduced logging through tools.logging. This choice was made made
mostly out of convenience. In any case it now allows bot authors to
see errors (at level `:error`) and all calls to `emit!` and `handle`
(at level `:debug`), which should prove widely useful.

This closes #21.
