### PR TITLE
[#27] Monitor websocket connectivity

### DIFF
--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -86,7 +86,15 @@
                    :on-receive
                    (fn [raw]
                      (emit! ::receive-message
-                       (read-str raw :key-fn string->keyword))))]
+                       (read-str raw :key-fn string->keyword)))
+                   :on-error
+                   (fn [& args]
+                     (log/error "Error in websocket.")
+                     (emit! ::websocket-errored args))
+                   :on-close
+                   (fn [& args]
+                     (log/warn "Closed websocket.")
+                     (emit! ::websocket-closed args)))]
       (reset! connection socket)
       (emit! ::websocket-connected url socket)
       (emit! ::bot-connected token))))

--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -90,7 +90,7 @@
                    :on-error
                    (fn [& args]
                      (log/error "Error in websocket.")
-                     (emit! ::websocket-errored args))
+                     (emit! ::websocket-erred args))
                    :on-close
                    (fn [& args]
                      (log/warn "Closed websocket.")


### PR DESCRIPTION
Slacker will now notice if its underlying websocket library loses
its connectivity and will report this both with logging and by
emitting respectively `::websocket-closed` and `::websocket-erred`
for closed connections and internal errors.
