### PR TITLE
[#33] Simplify `handle`

### DIFF
--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -4,6 +4,7 @@
   (:require
     [clojure.core.async :refer [<! >! chan go go-loop pub sub]]
     [clojure.data.json :refer [read-str]]
+    [clojure.stacktrace :refer [print-stack-trace]]
     [clojure.string :refer [lower-case]]
     [clojure.tools.logging :as log]
     [org.httpkit.client :as http]
@@ -34,90 +35,104 @@
     (emit!-template return-chan topic args)
     return-chan))
 
+(defmacro with-stacktrace-log
+  "Attempts to evaluate body and logs the stacktrace of any thrown throwable
+  as they would otherwise be difficult to notice given the asynchronous nature
+  of everything.
+
+  Wrap any expression for which error logging is desired in this macro."
+  [& body]
+  `(try
+     ~@body
+     (catch Throwable t#
+       (->> t#
+         print-stack-trace
+         with-out-str
+         (log/errorf "Error during 'handle' in ns=[%s]:\n%s" *ns*)))))
+
 (defn handle
   "Subscribes an event handler for the given topic. The handler will be called
   whenever an event is emitted for the given topic, and any optional args from
   emit! will be passed as arguments to the handler-fn."
-  ([topic docstring handler-fn]
-   (let [c (chan)]
-     (sub publication topic c)
-     (go-loop []
-       (when-let [[topic return-chan & msg] (<! c)]
-         (log/debugf "Handle: topic=[%s], ns=[%s], msg=[%s]" topic *ns* msg)
-         (go (try
-               (when-let [result (apply handler-fn msg)]
-                 (when return-chan
-                   (>! return-chan result)))
-               (catch Throwable t
-                 (->> t
-                   clojure.stacktrace/print-stack-trace
-                   with-out-str
-                   (log/errorf "Error in ns=[%s], handler=[%s]:\n%s"
-                               *ns* handler-fn)))))
-         (recur)))))
-  ([topic handler-fn]
-   (handle topic "I'm too lazy to describe my handlers." handler-fn)))
+  [topic handler-fn]
+  (let [c (chan)]
+    (sub publication topic c)
+    (go-loop []
+      (when-let [[topic return-chan & msg] (<! c)]
+        (go (with-stacktrace-log
+              (when-let [result (apply handler-fn msg)]
+                (when return-chan
+                  (>! return-chan result)))))
+          (recur)))
+    nil))
 
 ;; +--------------------------------------------------------------------------+
 ;; | Websockets                                                               |
 ;; +--------------------------------------------------------------------------+
 
-(handle ::connect-bot
+(defn connect-bot
   "Retrieves the websocket URL for a given bot token and emits this token in a
   command called ::connect-websocket commanding that a connection be made to
   the URL."
-  (fn [token]
-    (emit! ::connect-websocket
-      token
-      (-> (format "https://slack.com/api/rtm.start?token=%s" token)
-        (http/get)
-        (deref)
-        (:body)
-        (read-str :key-fn string->keyword)
-        (:url)))))
+  [token]
+  (emit! ::connect-websocket
+    token
+    (-> (format "https://slack.com/api/rtm.start?token=%s" token)
+      (http/get)
+      (deref)
+      (:body)
+      (read-str :key-fn string->keyword)
+      (:url))))
 
-(handle ::connect-websocket
+(handle ::connect-bot connect-bot)
+
+(defn connect-websocket
   "Connects to the websocket temporarily available at `url` and emits the
   following two events:
 
   [::websocket-connected url socket] for handlers interested in the socket.
   [::bot-connected token] for handlers interested in the token."
-  (fn [token url]
-    (let [socket (connect url
-                   :on-receive
-                   (fn [raw]
-                     (emit! ::receive-message
-                       (read-str raw :key-fn string->keyword)))
-                   :on-error
-                   (fn [& args]
-                     (log/error "Error in websocket.")
-                     (emit! ::websocket-erred args))
-                   :on-close
-                   (fn [& args]
-                     (log/warn "Closed websocket.")
-                     (emit! ::websocket-closed args)))]
-      (reset! connection socket)
-      (emit! ::websocket-connected url socket)
-      (emit! ::bot-connected token))))
+  [token url]
+  (let [socket (connect url
+                 :on-receive
+                 (fn [raw]
+                   (emit! ::receive-message
+                     (read-str raw :key-fn string->keyword)))
+                 :on-error
+                 (fn [& args]
+                   (log/error "Error in websocket.")
+                   (emit! ::websocket-erred args))
+                 :on-close
+                 (fn [& args]
+                   (log/warn "Closed websocket.")
+                   (emit! ::websocket-closed args)))]
+    (reset! connection socket)
+    (emit! ::websocket-connected url socket)
+    (emit! ::bot-connected token)))
+
+(handle ::connect-websocket connect-websocket)
 
 ;; +--------------------------------------------------------------------------+
 ;; | Message handling                                                         |
 ;; +--------------------------------------------------------------------------+
 
-(handle ::receive-message
+(defn receive-message
   "Handles the reception of a message by republishing it with a keywordized
   topic matching those described in the Slack API. This makes it easy to only
   subscribe to the kind of events you want, such as :message, :presence_change,
   etc."
-  (fn [msg]
-    (let [topic (cond (:type msg)     (:type msg)
-                      (:reply_to msg) "reply"
-                      :else           "unknown")]
-      (go (>! publisher [(string->keyword topic) msg])))))
+  [msg]
+  (let [topic (cond (:type msg)     (:type msg)
+                    (:reply_to msg) "reply"
+                    :else           "unknown")]
+    (go (>! publisher [(string->keyword topic) msg]))))
 
+(handle ::receive-message receive-message)
 
-(handle ::send-message
+(defn send-message
   "Sends a message to the currently open websocket. Takes a channel ID and a
   message in the form of a string."
-  (fn [receiver msg]
-    (send-msg @connection (string->slack-json receiver msg))))
+  [receiver msg]
+  (send-msg @connection (string->slack-json receiver msg)))
+
+(handle ::send-message send-message)


### PR DESCRIPTION
As per #33, the `handle` function has received a minor make-over and is less of a mess now:
-   Refactored "do with stacktrace logging" into a macro.
-   Sensible return value (always nil).
-   Doesn't concern itself with docstrings.

Merging this closes #33.
