### PR TITLE
Add connection smoke test

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,1 +1,4 @@
+#https://github.com/boot-clj/boot
+#Tue Oct 20 14:30:53 CEST 2015
 BOOT_CLOJURE_VERSION=1.7.0
+BOOT_VERSION=2.3.0

--- a/build.boot
+++ b/build.boot
@@ -7,7 +7,8 @@
     [org.clojure/core.async "0.1.346.0-17112a-alpha"]
     [org.clojure/data.json "0.2.6"]
     [org.clojure/tools.logging "0.3.1"]
-    [stylefruits/gniazdo "0.4.0"]])
+    [stylefruits/gniazdo "0.4.0"]
+    [environ "1.0.1"]])
 
 (require '[adzerk.bootlaces :refer :all])
 
@@ -22,9 +23,24 @@
        :url "https://github.com/emiln/slacker"
        :scm {:url "https://github.com/emiln/slacker"}})
 
-(deftask slacker-test
+(deftask unit-tests
   "Run the unit tests for Slacker in a pod."
   []
   (merge-env! :source-paths #{"unit-tests"})
   (require 'adzerk.boot-test)
   ((resolve 'adzerk.boot-test/test)))
+
+(deftask smoke-tests
+  "Run the smoke tests for Slacker in a pod."
+  []
+  (merge-env! :source-paths #{"smoke-tests"})
+  (require 'adzerk.boot-test)
+  ((resolve 'adzerk.boot-test/test)))
+
+(deftask tests
+  "Run the full test suite for Slacker in a pod."
+  []
+  (merge-env! :source-paths #{"unit-tests" "smoke-tests"})
+  (require 'adzerk.boot-test)
+  ((resolve 'adzerk.boot-test/test)))
+

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
 
   # Pin the Boot and Clojure version
   environment:
-    BOOT_CLOJURE_VERSION: 1.6.0
-    BOOT_VERSION: 2.0.0-rc14
+    BOOT_CLOJURE_VERSION: 1.7.0
+    BOOT_VERSION: 2.3.0
     JAVA_OPTS: -XXMaxPermSize=256m
 
 ## Download and install Boot
@@ -21,4 +21,4 @@ dependencies:
 ## Run the Slacker tests
 test:
   override:
-    - "boot slacker-test"
+    - "boot tests"

--- a/smoke-tests/connection_test.clj
+++ b/smoke-tests/connection_test.clj
@@ -1,0 +1,12 @@
+(ns connection-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [environ.core :refer [env]]
+            [slacker.client :refer [await! emit! handle]]))
+
+(deftest basic-connection
+  (testing "About connecting:"
+
+    (testing "A :hello event is received when connecting."
+      (let [token (env :slack-bot-token)]
+        (emit! :slacker.client/connect-bot token)
+        (is (await! :hello 5000)))))) 

--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -2,7 +2,7 @@
   "A simple Slack bot following an emit/handle flow. Read more about it in the
   README."
   (:require
-    [clojure.core.async :refer [<! <!! >! chan go go-loop pub sub]]
+    [clojure.core.async :refer [alts!! <! <!! >! chan go go-loop pub sub timeout]]
     [clojure.data.json :refer [read-str]]
     [clojure.stacktrace :refer [print-stack-trace]]
     [clojure.string :refer [lower-case]]
@@ -19,10 +19,12 @@
   "Blocks the thread, awaiting the occurrence of the given topic on the event
   channel. This is very handy for awaiting :slacker.client/bot-disconnected in
   the main function, which essentially blocks until the bot dies."
-  [topic]
+  [topic & [time-out]]
   (let [c (chan)]
     (sub publication topic c)
-    (<!! c)))
+    (if time-out
+      (first (alts!! [c (timeout time-out)]))
+      (<!! c))))
 
 (defn- emit!-template
   [return-chan topic args]


### PR DESCRIPTION
This PR adds a new category of tests: smoke tests. What's a smoke
test? When you plug your new fancy electronics device into the socket,
does sinister black smoke erupt from the circuits? Colloquially: does it
work at all in a real-life scenario?

The specific smoke test added attempts to connect to Slack using a Slack
bot token that is expected to be available as an environment variable
called `SLACK_BOT_TOKEN`. It will then await the `:hello` event from the
server and fail unless this is received within 5 seconds.

Awaiting an event in a test necessitated a slight modification to the
`await!` function: it will work as before, but now you can optionally
supply a second argument, which will be used as a timeout. If nothing
has happened within the timeout, nil is returned.

Accepting this closes #35.
