### PR TITLE
Emit event when connect-bot fails

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,11 +4,11 @@
   '[[adzerk/boot-test "1.0.4" :scope "test"]
     [adzerk/bootlaces "0.1.11" :scope "test"]
     [http-kit "2.1.19"]
-    [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+    [org.clojure/core.async "0.2.385"]
     [org.clojure/data.json "0.2.6"]
     [org.clojure/tools.logging "0.3.1"]
-    [stylefruits/gniazdo "0.4.0"]
-    [environ "1.0.1"]])
+    [stylefruits/gniazdo "1.0.0"]
+    [environ "1.0.3"]])
 
 (require '[adzerk.bootlaces :refer :all])
 


### PR DESCRIPTION
When connect-bot fails due to IO, incorrect credentials or otherwise,
the error only appears in the log, which makes it unnecessarily hard to
response to. This sort of error should really be handled through a
well-defined, general mechanism for errors, but as this doesn't exist
yet, I'm resorting to just emitting this simple event for now. That, at
least, allows users to respond to the failure.

It seems likely that I'll change my mind on how, exactly, errors should
be handled in the general case.

Closing this solves #49.
- [x] Emit event when Slacker fails to retrieve a URL to connect to.
- [x] Use qualified keyword on line 99.
- [x] Test that emission happens when payload is nil.
- [x] Test that emission happens when payload contains no URL.
